### PR TITLE
Adding Raid alert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Event.on_permission_check : (self, msg: Message, cmd: Command) -> bool # return 
 Event.on_after_command_execute : (self, msg: Message, cmd: Command)
 Event.on_before_command_execute : (self, msg: Message, cmd: Command) -> bool # return False to cancel command
 Event.on_bits_donated : (self, msg: Message, bits: int)
+Event.on_channel_raided : (self, channel: Channel, user: str, NumViewers: int)
 Event.on_channel_joined : (self, channel: Channel)
 Event.on_channel_subscription : (self, subscriber: str, channel: Channel, msg: Message)
 Event.on_privmsg_received : (self, msg: Message)

--- a/twitchbot/bots/basebot.py
+++ b/twitchbot/bots/basebot.py
@@ -97,6 +97,15 @@ class BaseBot:
         triggered when a bit donation is posted in chat
         """
         pass
+    
+    async def on_channel_raided(self, channel: Channel, user: str, NumViewers: int):
+        """
+        triggered when the channel is raided
+        :param channel: the channel who was raided
+        :param user: the user who raided
+        :param NumViewers: the number of viewers who joined in the raid
+        """
+        pass
 
     async def on_channel_joined(self, channel: Channel):
         """
@@ -306,7 +315,13 @@ class BaseBot:
                 mod_coro = trigger_mod_event(Event.on_channel_subscription, msg.author, msg.channel, msg,
                                              channel=msg.channel_name)
                 event_coro = trigger_event(Event.on_channel_subscription, msg.author, msg.channel, msg)
-
+                
+            elif msg.type is MessageType.RAID:
+                coro = self.on_channel_raided(msg.channel, msg.author, msg.tags.raid_count)
+                mod_coro = trigger_mod_event(Event.on_channel_raided, msg.channel, msg.author, msg.tags.raid_count, 
+                                             channel=msg.channel_name)
+                event_coro = trigger_event(Event.on_channel_raided, msg.channel, msg.author, msg.tags.raid_count)
+                
             elif msg.type is MessageType.PING:
                 self.irc.send_pong()
 

--- a/twitchbot/enums.py
+++ b/twitchbot/enums.py
@@ -24,6 +24,7 @@ class MessageType(NamedEnum):
     USER_JOIN = auto()
     USER_PART = auto()
     SUBSCRIPTION = auto()
+    RAID = auto()
     USER_NOTICE = auto()
     NONE = auto()
 
@@ -39,6 +40,7 @@ class Event(NamedEnum):
     on_after_command_execute = auto()
     on_bits_donated = auto()
     on_channel_subscription = auto()
+    on_channel_raided = auto()
     on_channel_joined = auto()
     on_connected = auto()
     on_privmsg_received = auto()

--- a/twitchbot/message.py
+++ b/twitchbot/message.py
@@ -103,8 +103,11 @@ class Message:
             self.channel = channels[m['channel']]
             self.author = self.tags.all_tags.get('login')
             self.content = m['content']
-            if self.tags.msg_id in {'sub', 'resub', 'subgift', 'anonsubgift', 'submysterygift'}:
+            if self.tags.msg_id in {'sub', 'resub', 'subgift', 'anonsubgift', 'submysterygift', 'anongiftpaidupgrade', 'giftpaidupgrade'}:
                 self.type = MessageType.SUBSCRIPTION
+            elif self.tags.msg_id == 'raid':
+                self.type = MessageType.RAID
+                self.author = self.tags.msg-param-login
             else:
                 self.type = MessageType.USER_NOTICE
 
@@ -131,6 +134,10 @@ class Message:
     @property
     def is_subscription(self):
         return self.type is MessageType.SUBSCRIPTION
+    
+    @property
+    def is_raid(self):
+        return self.type is MessageType.RAID
 
     @property
     def mention(self):
@@ -175,6 +182,9 @@ class Message:
 
         elif self.type is MessageType.SUBSCRIPTION:
             return f'{self.author} subscribed to {self.channel_name}: {self.system_message}'
+        
+        elif self.type is MessageType.RAID:
+            return f'{self.author} has raided {self.channel_name} with {self.tags.msg-param-viewerCount} viewers!'
 
         elif self.type is MessageType.USER_NOTICE:
             return f'USERNOTICE for {self.author}'

--- a/twitchbot/message.py
+++ b/twitchbot/message.py
@@ -184,8 +184,7 @@ class Message:
             return f'{self.author} subscribed to {self.channel_name}: {self.system_message}'
         
         elif self.type is MessageType.RAID:
-            numViewers = self.tags.all_tags.get("msg-param-viewerCount")
-            return f'{self.author} has raided {self.channel_name} with {numViewers} viewers!'
+            return f'{self.author} has raided {self.channel_name} with {self.tags.raid_count} viewers!'
 
         elif self.type is MessageType.USER_NOTICE:
             return f'USERNOTICE for {self.author}'

--- a/twitchbot/message.py
+++ b/twitchbot/message.py
@@ -107,7 +107,7 @@ class Message:
                 self.type = MessageType.SUBSCRIPTION
             elif self.tags.msg_id == 'raid':
                 self.type = MessageType.RAID
-                self.author = self.tags.msg-param-login
+                self.author = self.tags.all_tags.get('msg-param-login')
             else:
                 self.type = MessageType.USER_NOTICE
 
@@ -184,7 +184,8 @@ class Message:
             return f'{self.author} subscribed to {self.channel_name}: {self.system_message}'
         
         elif self.type is MessageType.RAID:
-            return f'{self.author} has raided {self.channel_name} with {self.tags.msg-param-viewerCount} viewers!'
+            numViewers = self.tags.all_tags.get("msg-param-viewerCount")
+            return f'{self.author} has raided {self.channel_name} with {numViewers} viewers!'
 
         elif self.type is MessageType.USER_NOTICE:
             return f'USERNOTICE for {self.author}'

--- a/twitchbot/modloader.py
+++ b/twitchbot/modloader.py
@@ -112,6 +112,12 @@ class Mod:
         """
         triggered when a bit donation is posted in chat
         """
+    async def on_channel_raided(self, channel: Channel, NumViewers: int):
+        """
+        triggered when the current channel is raided
+        :param channel: the channel who raided
+        :param NumViewers: the number of viewers who joined in the raid
+        """
 
     async def on_channel_joined(self, channel: Channel):
         """

--- a/twitchbot/modloader.py
+++ b/twitchbot/modloader.py
@@ -113,10 +113,11 @@ class Mod:
         triggered when a bit donation is posted in chat
         """
 
-    async def on_channel_raided(self, channel: Channel, NumViewers: int):
+    async def on_channel_raided(self, channel: Channel, user: str, NumViewers: int):
         """
-        triggered when the current channel is raided
-        :param channel: the channel who raided
+        triggered when the channel is raided
+        :param channel: the channel who was raided
+        :param user: the user who raided
         :param NumViewers: the number of viewers who joined in the raid
         """
 

--- a/twitchbot/modloader.py
+++ b/twitchbot/modloader.py
@@ -112,6 +112,7 @@ class Mod:
         """
         triggered when a bit donation is posted in chat
         """
+
     async def on_channel_raided(self, channel: Channel, NumViewers: int):
         """
         triggered when the current channel is raided

--- a/twitchbot/tags.py
+++ b/twitchbot/tags.py
@@ -17,6 +17,7 @@ class Tags:
         self.bits_leader: int = self.all_tags.get('bits-leader')
         self.broadcaster: int = self.badges.get('broadcaster', 0)
         self.msg_id: str = self.all_tags.get('msg-id')
+        self.raid_count: int = _try_parse_int(self.all_tags.get('msg-param-viewerCount'))
 
         # bit_leader is initially a string, it is then parsed into a int here
         if self.bits_leader:


### PR DESCRIPTION
I have not fully tested this and it's been awhile since I've used python (I'll probably have my bot running next stream so we'll see there if the Raid feature works, haha). 

I'm open to changes, but really wanted to see Raid support added.

Also added the two other gift sub notices, to the list of things that trigger the subscriptions. They probably could be further supported though.

Apologies for the number of commits, it's quicker to just edit it on the web :P

Thanks for this project, way faster than having to write my own!