### PR TITLE
Make sql objects friendlier to multithreaded environments

### DIFF
--- a/twitchbot/database/session.py
+++ b/twitchbot/database/session.py
@@ -2,7 +2,12 @@ from sqlalchemy import create_engine, orm
 from sqlalchemy.ext.declarative import declarative_base
 from ..config import mysql_cfg
 
-__all__ = ('Base', 'engine', 'session', 'DB_FILENAME', 'init_tables')
+__all__ = ('Base', 'engine', 'session', 'DB_FILENAME', 'init_tables', 'connect_database', 'shutdown_database')
+
+DB_FILENAME = 'database.sqlite'
+Base = declarative_base()
+engine = None
+session: orm.Session = None
 
 if mysql_cfg.enabled:
     try:
@@ -13,14 +18,30 @@ if mysql_cfg.enabled:
         input('\npress enter to exit...')
         exit(1)
 
-Base = declarative_base()
-DB_FILENAME = 'database.sqlite'
-engine = create_engine(f'sqlite:///{DB_FILENAME}'
+def connect_database():
+    global engine
+    global session
+     
+    engine = create_engine(f'sqlite:///{DB_FILENAME}'
                        if not mysql_cfg.enabled else
                        f'mysql+mysqlconnector://{mysql_cfg.username}:{mysql_cfg.password}@{mysql_cfg.address}:{mysql_cfg.port}/{mysql_cfg.database}')
-Session = orm.sessionmaker(bind=engine)
-session: orm.Session = Session()
+    Session = orm.sessionmaker(bind=engine)
+    session = Session()
 
-
+def shutdown_database():
+    global engine
+    global session
+    
+    session.commit()
+    session.close()
+    session = None
+    engine.dispose()
+    engine = None
+    
 def init_tables():
+    if engine is None:
+        return
+    
     Base.metadata.create_all(engine)
+
+connect_database()


### PR DESCRIPTION
Really quick hack to make the SQL database access and objects more multithread friendly. For most uses and implementations, this will do nothing. However, should someone need the ability, this exposes and provides methods of manipulating database objects for the framework.

The plus side of going with this solution is that it shouldn't negatively affect current initialization sequences requiring them to be rewritten or encapsulated, and mods/commands should require minimal to no changes (depending on what's in them). 

A better, safer method would be an entire encapsulation for data safety but could negatively affect overall performance. Thus, with this solution these functions are provided as a sort of "if you call these directly you know what you're doing" ideology.

Appears to work properly in tests. Alternatives could be to use scoped_sessions, so long as the engine is properly set up.