### PR TITLE
Update listpolls command to return appropriate message if there are no active polls

### DIFF
--- a/twitchbot/builtin_commands/poll_commands.py
+++ b/twitchbot/builtin_commands/poll_commands.py
@@ -69,7 +69,11 @@ async def cmd_vote(msg: Message, *args):
 
 @Command('listpolls', help='list all active polls', permission=LIST_POLLS_PERMISSION)
 async def cmd_list_polls(msg: Message, *args):
-    await msg.reply(' '.join(f'{poll.id}) {poll.title}' for poll in get_active_channel_polls(msg.channel_name)))
+    polls = get_active_channel_polls(msg.channel_name)
+    if polls:
+        await msg.reply(" ".join(f"{poll.id}) {poll.title}" for poll in polls))
+    else:
+        await msg.reply("There are currently no active polls.")
 
 
 @Command('pollinfo', syntax='(POLL_ID)', help='views info about the poll using the passed poll id', permission=POLL_INFO_PERMISSION)


### PR DESCRIPTION
Currently it gives a ValueError because you cannot send an empty message if you run the command !listpolls when there are none active.

This PR simply checks for the polls and adjusts the message to be appropriate if none exist.