### PR TITLE
Fix for errors when command_server connection is closed normally.

### DIFF
--- a/twitchbot/command_server.py
+++ b/twitchbot/command_server.py
@@ -178,7 +178,8 @@ class ClientHandler:
                     await self.handle_run_command(data)
         except ConnectionResetError:
             return
-
+        except websockets.exceptions.ConnectionClosedOK:
+            pass
 
 async def handle_client(websocket: websockets.WebSocketServerProtocol, path: str):
     await ClientHandler(websocket, path).run()


### PR DESCRIPTION
When a client closes the connection with the command server websockets.exceptions.CommandClosedOK is raised.
This PR ignores that and prevents a traceback from being shown in the console.