### PR TITLE
Handle Twitchemotes api failing

### DIFF
--- a/twitchbot/emote.py
+++ b/twitchbot/emote.py
@@ -18,5 +18,8 @@ async def update_global_emotes():
     _, data = await get_url(GLOBAL_EMOTE_API)
     emotes.clear()
 
+    if not 'emotes' in data:
+        return
+
     for emote in data['emotes']:
         emotes[emote['code']] = Emote(int(emote['id']), emote['code'], emote['emoticon_set'])


### PR DESCRIPTION
If the twitch emotes api returns any error, this causes the entire bot to stop processing. Instead of allowing this to happen, we do a check to see if the 'emotes' key exists in the output json. If it does not, then we give up on trying to update the global emotes.