### PR TITLE
Update of stream info api fails.

### DIFF
--- a/twitchbot/api/streaminfoapi.py
+++ b/twitchbot/api/streaminfoapi.py
@@ -28,14 +28,14 @@ class StreamInfoApi(Api):
         """
         try:
             data = await util.get_stream_data(self.user, self.headers)
-            self.viewer_count = data['viewer_count']
-            self.title = data['title']
-            self.game_id = data['game_id']
+            self.viewer_count = data.get('viewer_count', 0)
+            self.title = data.get('title', '')
+            self.game_id = data.get('game_id', 0)
             # self.community_ids = frozenset(data['community_ids'])
             #                                                      2018-05-17T16:47:46Z
-            self.started_at = datetime.strptime(data['started_at'], '%Y-%m-%dT%H:%M:%SZ')
-            self.user_id = data['user_id']
-            self.tag_ids = frozenset(data['tag_ids'])
+            self.started_at = datetime.strptime(data['started_at'], '%Y-%m-%dT%H:%M:%SZ') if 'started_at' in data else datetime.min
+            self.user_id = data.get('user_id', 0)
+            self.tag_ids = frozenset(data.get('tag_ids', {}))
 
             await self.on_successful_update()
         except Exception as e:

--- a/twitchbot/api/streaminfoapi.py
+++ b/twitchbot/api/streaminfoapi.py
@@ -27,7 +27,7 @@ class StreamInfoApi(Api):
         :param log: should errors be logged?
         """
         try:
-            data = await util.get_stream_data(self.user, self.headers)
+            data = await util.get_stream_data(self.user)
             self.viewer_count = data.get('viewer_count', 0)
             self.title = data.get('title', '')
             self.game_id = data.get('game_id', 0)

--- a/twitchbot/util/twitch_api_util.py
+++ b/twitchbot/util/twitch_api_util.py
@@ -26,7 +26,7 @@ user_id_cache: Dict[str, int] = {}
 
 
 async def get_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     async with ClientSession(headers=headers) as session:
         async with timeout(10):
             async with session.get(url) as resp:
@@ -34,7 +34,7 @@ async def get_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]
 
 
 async def post_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     async with ClientSession(headers=headers) as session:
         async with timeout(10):
             async with session.post(url) as resp:
@@ -78,7 +78,7 @@ async def get_user_creation_date(user: str) -> datetime:
 
 
 async def get_user_followers(user: str, headers: dict = None) -> UserFollowers:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     user_id = await get_user_id(user, headers)
     _, json = await get_url(USER_FOLLOWERS_API_URL.format(user_id), get_headers())
     ratelimit = RateLimit.from_headers(_.headers)
@@ -96,7 +96,7 @@ async def get_user_followers(user: str, headers: dict = None) -> UserFollowers:
 
 
 async def get_user_data(user: str, headers: dict = None) -> dict:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     _, json = await get_url(USER_API_URL.format(user), headers)
 
     if not json.get('data'):
@@ -106,7 +106,7 @@ async def get_user_data(user: str, headers: dict = None) -> dict:
 
 
 async def get_user_id(user: str, headers: dict = None, verbose=True) -> int:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     # shortcut if the this user's id was already requested
     if user in user_id_cache:
         return user_id_cache[user]
@@ -123,7 +123,7 @@ async def get_user_id(user: str, headers: dict = None, verbose=True) -> int:
 
 
 async def get_stream_data(user_id: str, headers: dict = None) -> dict:
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     _, json = await get_url(STREAM_API_URL.format(user_id), headers)
 
     if not json.get('data'):
@@ -187,7 +187,7 @@ async def get_channel_name_from_user_id(user_id: str, headers: dict = None) -> s
     if user_id in _channel_id_to_name_cache:
         return _channel_id_to_name_cache[user_id]
 
-    headers = headers or get_headers()
+    headers = headers if headers and len(headers) == 2 else get_headers()
     channel_info = await get_channel_info(user_id, headers=headers)
 
     if not channel_info:

--- a/twitchbot/util/twitch_api_util.py
+++ b/twitchbot/util/twitch_api_util.py
@@ -26,7 +26,7 @@ user_id_cache: Dict[str, int] = {}
 
 
 async def get_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]:
-    headers = headers if headers and len(headers) == 2 else get_headers()
+    headers = headers if headers is not None else get_headers()
     async with ClientSession(headers=headers) as session:
         async with timeout(10):
             async with session.get(url) as resp:
@@ -34,7 +34,7 @@ async def get_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]
 
 
 async def post_url(url: str, headers: dict = None) -> Tuple[ClientResponse, dict]:
-    headers = headers if headers and len(headers) == 2 else get_headers()
+    headers = headers if headers is not None else get_headers()
     async with ClientSession(headers=headers) as session:
         async with timeout(10):
             async with session.post(url) as resp:


### PR DESCRIPTION
When the stream is offline, it will return empty information and will not be updated.
It may also fail because the headers does not contain the oauth key.