### PR TITLE
Added an implementation of counters with custom command integration

### DIFF
--- a/twitchbot/builtin_commands/custom_commands.py
+++ b/twitchbot/builtin_commands/custom_commands.py
@@ -24,7 +24,7 @@ def _verify_resp_is_valid(resp: str):
          help='adds a custom command to the database for the this channel, '
               'placeholders: %user : the name of the person that triggered the command,'
               '%uptime : the channels live uptime,'
-              '%channel : the channels name')
+              '%channel : the channels name, %counter adds and uses a counter starting with the value 0')
 async def cmd_add_custom_command(msg: Message, *args):
     if len(args) < 2:
         raise InvalidArgumentsError(reason='missing required arguments', cmd=cmd_add_custom_command)

--- a/twitchbot/builtin_commands/dbcounter_commands.py
+++ b/twitchbot/builtin_commands/dbcounter_commands.py
@@ -11,7 +11,8 @@ from twitchbot import (
     DBCounter,
     get_counter,
     delete_counter_by_id,
-    set_counter
+    set_counter,
+    get_all_counters
 )
 
 PREFIX = cfg.prefix
@@ -87,3 +88,8 @@ async def cmd_set_counter(msg: Message, *args):
     new_val = set_counter(channel=msg.channel_name, id_or_alias=alias, new_value=value)
 
     await msg.reply(f'The counter {alias} has been updated to {new_val}')
+
+@Command('listcounters', permission='manage_counter', help='list all counters of the channel')
+async def cmd_set_counter(msg: Message, *args):
+    clist = ', '.join(str(x) for x in get_all_counters(msg.channel_name))
+    await msg.reply(f'The following counters are available: {clist}')

--- a/twitchbot/builtin_commands/dbcounter_commands.py
+++ b/twitchbot/builtin_commands/dbcounter_commands.py
@@ -1,0 +1,89 @@
+import re
+from sqlalchemy import Integer
+
+from twitchbot import (
+    Command,
+    Message,
+    cfg,
+    InvalidArgumentsError,
+    get_counter_by_alias,
+    add_counter,
+    DBCounter,
+    get_counter,
+    delete_counter_by_id,
+    set_counter
+)
+
+PREFIX = cfg.prefix
+
+@Command('addcounter', permission='manage_counter', syntax='<ALIAS>', help='adds a counter to the database')
+async def cmd_add_counter(msg: Message, *args):
+    if not args:
+        raise InvalidArgumentsError(reason='missing required arguments', cmd=cmd_add_counter)
+
+    alias = args[0]
+
+    m = re.search(r'([\d\w]+)', alias)
+    if not m:
+        raise InvalidArgumentsError(
+            reason='invalid alias , must be a combination of digits and letters, ex: my_counter1',
+            cmd=cmd_add_counter)
+
+    alias = m.group(1)
+    if get_counter_by_alias(msg.channel_name, alias) is not None:
+        raise InvalidArgumentsError(reason='there is already a counter with that alias', cmd=cmd_add_counter)
+
+    counter = DBCounter.create(channel=msg.channel_name, alias=alias)
+    if add_counter(counter):
+        resp = f'successfully added counter #{counter.id}'
+    else:
+        resp = 'failed to add counter, already exist'
+
+    await msg.reply(resp)
+
+
+@Command('delcounter', permission='manage_counter', syntax='<ID or ALIAS>', help='deletes the counter from the database')
+async def cmd_del_counter(msg: Message, *args):
+    if not args:
+        raise InvalidArgumentsError(reason='missing required argument', cmd=cmd_del_counter)
+
+    counter = get_counter(msg.channel_name, args[0])
+    if counter is None:
+        raise InvalidArgumentsError(reason='no counter found', cmd=cmd_del_counter)
+
+    delete_counter_by_id(msg.channel_name, counter.id)
+    await msg.reply(f'successfully deleted counter, id: {counter.id}, alias: {counter.alias}')
+
+
+@Command('setcounter', permission='manage_counter', syntax='alias=(alias) value=(value)', help='adds a counter to the database')
+async def cmd_set_counter(msg: Message, *args):
+    if not args:
+        raise InvalidArgumentsError(reason='missing required arguments', cmd=cmd_set_counter)
+
+    optionals = ' '.join(args[0:])
+
+    alias = None
+    if 'alias=' in optionals:
+        m = re.search(r'alias=([\d\w]+)', msg.content)
+        if not m:
+            raise InvalidArgumentsError(
+                reason='invalid alias for alias=, must be a combination of digits and letters, ex: my_counter1',
+                cmd=cmd_set_counter)
+
+        alias = m.group(1)
+        if get_counter_by_alias(msg.channel_name, alias) is None:
+            raise InvalidArgumentsError(reason='there is no counter with das alias', cmd=cmd_set_counter)
+
+    value = None
+    if 'value=' in optionals:
+        m = re.search(r'value=([\d]+)', msg.content)
+        if not m:
+            raise InvalidArgumentsError(
+                reason='invalid value, only numbers are allowed',
+                cmd=cmd_set_counter)
+
+        value = m.group(1)
+
+    new_val = set_counter(channel=msg.channel_name, id_or_alias=alias, new_value=value)
+
+    await msg.reply(f'The counter {alias} has been updated to {new_val}')

--- a/twitchbot/command.py
+++ b/twitchbot/command.py
@@ -6,6 +6,7 @@ from typing import Dict, Callable, Optional, List, Tuple
 
 from twitchbot.database import CustomCommand
 from twitchbot.message import Message
+from twitchbot.database.dbcounter import increment_or_add_counter
 from .config import cfg
 from .enums import CommandContext
 from .util import get_py_files, get_file_name
@@ -201,7 +202,7 @@ def _calc_channel_live_time(msg) -> str:
 CUSTOM_COMMAND_PLACEHOLDERS = (
     (
         '%user',
-        lambda msg: f'@{msg.author}'
+        lambda msg, name: f'@{msg.author}'
     ),
     (
         '%uptime',
@@ -209,7 +210,11 @@ CUSTOM_COMMAND_PLACEHOLDERS = (
     ),
     (
         '%channel',
-        lambda msg: msg.channel_name
+        lambda msg, name: msg.channel_name
+    ),
+    (
+        '%counter',
+        lambda msg, name: str(increment_or_add_counter(msg.channel_name, name))
     ),
 )
 
@@ -225,7 +230,7 @@ class CustomCommandAction(Command):
 
         for placeholder, func in CUSTOM_COMMAND_PLACEHOLDERS:
             if placeholder in resp:
-                resp = resp.replace(placeholder, func(msg))
+                resp = resp.replace(placeholder, func(msg, self.cmd.name))
 
         await msg.channel.send_message(resp)
 

--- a/twitchbot/database/__init__.py
+++ b/twitchbot/database/__init__.py
@@ -4,3 +4,4 @@ from .session import *
 from .models import *
 from .currency import *
 from .message_timer import *
+from .dbcounter import *

--- a/twitchbot/database/dbcounter.py
+++ b/twitchbot/database/dbcounter.py
@@ -1,10 +1,12 @@
 from sqlalchemy import Integer
-from typing import Union, Optional
+from typing import Union, Optional, List
 
 from .session import session
 from .models import DBCounter
 
-__all__ = ('counter_exist', 'add_counter', 'increment_counter', 'increment_or_add_counter',  'set_counter', 'delete_counter_by_id', 'delete_counter_by_alias', 'get_counter_by_id', 'get_counter_by_alias', 'get_counter')
+__all__ = ('counter_exist', 'get_all_counters', 'add_counter', 'increment_counter', 'increment_or_add_counter',  
+    'set_counter', 'delete_counter_by_id', 'delete_counter_by_alias', 
+    'get_counter_by_id', 'get_counter_by_alias', 'get_counter')
 
 
 
@@ -106,3 +108,8 @@ def set_counter(channel: str, id_or_alias: Union[str, int], new_value) -> Option
     session.commit()
     return cur_counter.value
 
+def get_all_counters(channel: str) -> List[DBCounter]:
+    """
+    retrieve all counters from the current channel
+    """
+    return session.query(DBCounter).filter(DBCounter.channel == channel).all()

--- a/twitchbot/database/dbcounter.py
+++ b/twitchbot/database/dbcounter.py
@@ -1,0 +1,98 @@
+from collections import Counter
+from sqlalchemy import Column, Integer, String
+from typing import Union, Optional
+
+from .session import session
+from .models import DBCounter
+
+__all__ = ('counter_exist', 'add_counter', 'increment_counter', 'set_counter', 'delete_counter_by_id', 'delete_counter_by_alias', 'get_counter_by_id', 'get_counter_by_alias', 'get_counter')
+
+
+
+
+def counter_exist(channel: str, id: int = None, alias: str = None) -> bool:
+    """return if counter exist that has the same ID or ALIAS or both"""
+
+    if id is None and alias is None:
+        return False
+
+    filters = [DBCounter.channel == channel]
+
+    if id is not None:
+        filters.append(DBCounter.id == id)
+    if alias is not None:
+        filters.append(DBCounter.alias == alias)
+
+    return bool(session.query(DBCounter).filter(*filters).count())
+
+
+def add_counter(counter: DBCounter) -> bool:
+    """adds a counter to the counter DB, return a bool indicating if it was successful"""
+    assert isinstance(counter, DBCounter), 'counter must of type Counter'
+
+    if counter_exist(counter.channel, counter.id, counter.alias):
+        return False
+
+    session.add(counter)
+    session.commit()
+    return True
+
+def get_counter_by_id(channel: str, id: int) -> Optional[DBCounter]:
+    assert isinstance(id, int), 'counter_id must be of type int'
+    return session.query(DBCounter).filter(DBCounter.id == id, DBCounter.channel == channel).one_or_none()
+
+
+def get_counter_by_alias(channel: str, alias: str) -> Optional[DBCounter]:
+    assert isinstance(alias, str), 'counter_alias must be of type str'
+    return session.query(DBCounter).filter(DBCounter.alias == alias, DBCounter.channel == channel).one_or_none()
+
+def get_counter(channel: str, id_or_alias: Union[str, int]) -> Optional[DBCounter]:
+    """
+    tries to find counter by parsing x to int first (uses value if its already a int),
+    then tries to find counter using x as a alias
+    returns the counter if one exist, else None
+    """
+    try:
+        return get_counter_by_id(channel, int(id_or_alias))
+    except (ValueError, TypeError):
+        return get_counter_by_alias(channel, str(id_or_alias))
+
+def delete_counter_by_id(channel: str, id: int) -> None:
+    assert isinstance(id, int), 'counter_id must be of type int'
+    session.query(DBCounter).filter(DBCounter.channel == channel, DBCounter.id == id).delete()
+    session.commit()
+
+
+def delete_counter_by_alias(channel: str, alias: str) -> None:
+    assert isinstance(alias, str), 'counter_alias must be of type str'
+    session.query(DBCounter).filter(DBCounter.channel == channel, DBCounter.alias == alias).delete()
+    session.commit()
+
+
+def increment_counter(channel: str, id_or_alias: Union[str, int]) -> Integer:
+    """
+    tries to set  the counter an returns the new counter value
+    """
+    cur_counter = get_counter(channel, id_or_alias)
+    if cur_counter is None:
+        return -1
+    
+    cur_counter.value = DBCounter.value + 1
+
+    session.commit()
+    return cur_counter.value
+
+
+def set_counter(channel: str, id_or_alias: Union[str, int], new_value) -> Integer:
+    """
+    tries to set counter an returns the new counter value
+    """
+    cur_counter = get_counter(channel, id_or_alias)
+    if cur_counter is None:
+        return -1
+    
+    cur_counter.value = new_value
+
+    session.commit()
+    return cur_counter.value
+

--- a/twitchbot/database/models.py
+++ b/twitchbot/database/models.py
@@ -101,3 +101,6 @@ class DBCounter(Base):
     @classmethod
     def create(cls, channel: str, value: int = 0, user: str = None, alias: str = None):
         return DBCounter(channel=channel.lower(), user=user, value=value, alias=alias)
+    
+    def __str__(self):
+        return f'{self.alias} -> {self.value}'

--- a/twitchbot/database/models.py
+++ b/twitchbot/database/models.py
@@ -6,7 +6,7 @@ from .session import Base
 from ..config import cfg
 from ..enums import CommandContext
 
-__all__ = ('Quote', 'CustomCommand', 'Balance', 'CurrencyName', 'MessageTimer')
+__all__ = ('Quote', 'CustomCommand', 'Balance', 'CurrencyName', 'MessageTimer', 'DBCounter')
 
 
 class Quote(Base):
@@ -88,3 +88,16 @@ class MessageTimer(Base):
     @classmethod
     def create(cls, channel: str, name: str, message: str, interval: float, active=False):
         return MessageTimer(name=name, channel=channel, message=message, interval=interval, active=active)
+
+class DBCounter(Base):
+    __tablename__ = 'counter'
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    user = Column(String(255))
+    channel = Column(String(255), nullable=False)
+    alias = Column(String(255))
+    value = Column(Integer, nullable=False)
+
+    @classmethod
+    def create(cls, channel: str, value: int = 0, user: str = None, alias: str = None):
+        return DBCounter(channel=channel.lower(), user=user, value=value, alias=alias)


### PR DESCRIPTION
The framework is extendet by a database based counter functionallity.

Additions:
Permissions: manager_counter
Commands: addcounter, delcounter, setcounter, listcounters
Counter support for custom commands with placeholder %counter. The complete command name "!command" is used as alias.

For easier usage a function "increment_or_add_counter" is implemented, which will just create a counter, if not already existing.
All counters can be manipulated with the above mentioned commands.

Limitations: 
Only one counter per custom (database) command is supported.
