### PR TITLE
fix CooldownManager.on_cooldown for uninitialized keys

### DIFF
--- a/twitchbot/util/cooldown_manager.py
+++ b/twitchbot/util/cooldown_manager.py
@@ -22,7 +22,10 @@ class CooldownManager:
         return datetime.now() - self.get(key, datetime.min)
 
     def on_cooldown(self, key: Hashable, required_min_seconds: Union[int, float, Decimal]) -> bool:
-        return self.elapsed_seconds(key) < required_min_seconds
+        if key not in self:
+            return False
+        else:
+            return self.elapsed_seconds(key) < required_min_seconds
 
     def seconds_left(self, key: Hashable, required_min_seconds: Union[int, float, Decimal]):
         return required_min_seconds - (datetime.now() - self.get(key, datetime.now())).total_seconds()


### PR DESCRIPTION
If CooldownManager.on_cooldown encounters a key that is not registered, then elapsed_seconds returns 0, which is interpreted as 'the command was just run', meaning that the command is always on cooldown. This commit changes behavior of on_cooldown so that it returns False for uninitialized keys (so that they can actually be initialized once the command is run and put on cooldown).